### PR TITLE
A few questions.

### DIFF
--- a/mop/lib/mop/internal/util.pm
+++ b/mop/lib/mop/internal/util.pm
@@ -246,6 +246,7 @@ sub INSTALL_FINALIZATION_RUNNER {
             # an eval STRING;
             || (caller(3))[3] eq '(eval)';
 
+    # Any reason to use private API instead of public here?
     push @{ Devel::Hook::_get_unitcheck_array() } => (
         sub { mop::module->new( name => $pkg )->run_all_finalizers }
     );


### PR DESCRIPTION
This PR has one question on the code directly (but nothing to actually merge, just start discussion). 

Aside from that:

You can specify a non-sub for @HAS attributes:

```
@HAS = ( x => {} ),
```

This will crash at _runtime_ with a not-a-code-reference. Would it be possible/better to do this check at compile time (unitcheck?) when finalizing the class to make sure attributes are properly formed?

Also, $IS_ABSTRACT/$IS_CLOSED are writeable after the class has been compiled, should this be
locked somehow? Deleting/modifying %HAS also modifies closed objects after they are supposed to have a consistent state. Is this acceptable/intentional?

One final thing, ->new() doesn't check for invalid parameters being passed to the constructor. Should it? Or is that up to a sugar layer? 
