### PR TITLE
Use new overload_op_info() function to check for codulatability

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -30,7 +30,7 @@ Symbol              = 0
 Scalar::Util        = 0
 Sub::Metadata       = 0
 Sub::Util           = 0
-Devel::OverloadInfo = 0
+Devel::OverloadInfo = 0.005
 Devel::Hook         = 0
 UNIVERSAL::Object   = 0.14
 

--- a/lib/MOP/Internal/Util.pm
+++ b/lib/MOP/Internal/Util.pm
@@ -138,8 +138,7 @@ sub CAN_COERCE_TO_CODE_REF {
     # might be just a blessed CODE ref ...
     return 1 if Scalar::Util::reftype( $object ) eq 'CODE';
     # or might be overloaded object ...
-    return 0 unless Devel::OverloadInfo::is_overloaded( $object );
-    return exists Devel::OverloadInfo::overload_info( $object )->{'&{}'};
+    return defined Devel::OverloadInfo::overload_op_info( $object, '&{}' );
 }
 
 sub IS_CV_NULL {


### PR DESCRIPTION
Also, no need to separately check is_overloaded(), overload_op_info()
does that anyway.