### PR TITLE
correct POD rendering issue using "C<< ... >>"

### DIFF
--- a/lib/MOP/Role.pm
+++ b/lib/MOP/Role.pm
@@ -812,7 +812,7 @@ defintions, and I<may> consume other roles.
 
 =over 4
 
-=item C<new( name => $package_name )>
+=item C<< new( name => $package_name ) >>
 
 =item C<new( $package_name )>
 


### PR DESCRIPTION
Currently the POD renders as follows:

    "new( name =" $package_name )>

Changing the [formatting codes](https://perldoc.perl.org/perlpodspec.html#Pod-Formatting-Codes) renders it as intended:

    "new( name => $package_name )"